### PR TITLE
Update to latest akka typed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,19 +1,20 @@
 name := "akka-typed-session"
 version := "0.1.0-SNAPSHOT"
 organization := "com.rolandkuhn"
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.5"
 
-scalacOptions += "-deprecation"
+//scalacOptions += "-deprecation"
 logBuffered in Test := false
 
-val akkaVersion = "2.5.99-TYPED-M1"
+// Update to 2.5.12 once released. Current SNAPSHOT has many API changes over 2.5.11
+val akkaVersion = "2.5-SNAPSHOT"
 
 resolvers += "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/"
 
 libraryDependencies ++= Seq(
-  "com.chuusai" %% "shapeless" % "2.3.2",
-  "com.typesafe.akka" %% "akka-typed" % akkaVersion,
-  "com.typesafe.akka" %% "akka-typed-testkit" % akkaVersion % "test",
+  "com.chuusai" %% "shapeless" % "2.3.3",
+  "com.typesafe.akka" %% "akka-actor-typed" % akkaVersion,
+  "com.typesafe.akka" %% "akka-testkit-typed" % akkaVersion % "test",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.1.0

--- a/src/main/scala/com/rolandkuhn/akka_typed_session/Actor.scala
+++ b/src/main/scala/com/rolandkuhn/akka_typed_session/Actor.scala
@@ -3,7 +3,7 @@
  */
 package com.rolandkuhn.akka_typed_session
 
-import akka.typed.ActorRef
+import akka.actor.typed.ActorRef
 
 /**
  * The main ActorRef of an Actor hosting [[Process]] instances accepts this

--- a/src/main/scala/com/rolandkuhn/akka_typed_session/Effects.scala
+++ b/src/main/scala/com/rolandkuhn/akka_typed_session/Effects.scala
@@ -3,7 +3,7 @@
  */
 package com.rolandkuhn.akka_typed_session
 
-import akka.typed._
+import akka.actor.typed._
 import shapeless.{ Coproduct, :+:, CNil }
 import shapeless.test.illTyped
 import scala.annotation.implicitNotFound

--- a/src/main/scala/com/rolandkuhn/akka_typed_session/Operation.scala
+++ b/src/main/scala/com/rolandkuhn/akka_typed_session/Operation.scala
@@ -3,7 +3,7 @@
  */
 package com.rolandkuhn.akka_typed_session
 
-import akka.typed.{ ActorSystem, ActorRef, Behavior, Props }
+import akka.actor.typed.{ ActorSystem, ActorRef, Behavior, Props }
 import akka.{ actor => a }
 import shapeless.{ Coproduct, :+:, CNil }
 import shapeless.ops._

--- a/src/main/scala/com/rolandkuhn/akka_typed_session/Process.scala
+++ b/src/main/scala/com/rolandkuhn/akka_typed_session/Process.scala
@@ -4,10 +4,12 @@
 package com.rolandkuhn.akka_typed_session
 
 import scala.concurrent.duration.Duration
-import akka.{ actor => a }
-import akka.typed.Behavior
-import akka.typed.scaladsl.Actor
-import shapeless.{ :+:, CNil }
+import akka.{actor => a}
+import akka.actor.typed._
+import akka.actor.typed.scaladsl.Behaviors
+import shapeless.{:+:, CNil}
+
+import scala.reflect.ClassTag
 
 /**
  * A Process runs the given operation steps in a context that provides the
@@ -84,5 +86,5 @@ final case class Process[S, +Out, E <: Effects](
   /**
    * Convert to a runnable [[Behavior]], e.g. for being used as the guardian of an [[ActorSystem]].
    */
-  def toBehavior: Behavior[ActorCmd[S]] = Actor.deferred(ctx => new internal.ProcessInterpreter(this, ctx).execute(ctx))
+  def toBehavior: Behavior[ActorCmd[S]] = Behaviors.setup(ctx => new internal.ProcessInterpreter(this, ctx).execute(ctx))
 }

--- a/src/test/scala/com/rolandkuhn/akka_typed_session/auditdemo/AkkaTyped.scala
+++ b/src/test/scala/com/rolandkuhn/akka_typed_session/auditdemo/AkkaTyped.scala
@@ -12,10 +12,10 @@ class Greeter extends akka.actor.Actor {
 }
 
 object Greeter {
-  import akka.typed.scaladsl.Actor
+  import akka.actor.typed.scaladsl.Behaviors
   val behavior =
-    Actor.immutable[Greet] { (ctx, greet) =>
+    Behaviors.receive[Greet] { (_, greet) =>
       println(s"Hello ${greet.whom}!")
-      Actor.same
+      Behaviors.same
     }
 }

--- a/src/test/scala/com/rolandkuhn/akka_typed_session/auditdemo/Messages.scala
+++ b/src/test/scala/com/rolandkuhn/akka_typed_session/auditdemo/Messages.scala
@@ -4,12 +4,15 @@
 package com.rolandkuhn.akka_typed_session
 package auditdemo
 
-import akka.typed.ActorRef
+import akka.actor.typed.ActorRef
 import java.net.URI
 import java.util.UUID
-import akka.typed.patterns.Receptionist.ServiceKey
 
-case object AuditService extends ServiceKey[LogActivity]
+import akka.actor.typed.receptionist.ServiceKey
+
+object AuditService {
+ val Key = ServiceKey[LogActivity]("audit-service")
+}
 case class LogActivity(who: ActorRef[Nothing], what: String, id: Long, replyTo: ActorRef[ActivityLogged])
 case class ActivityLogged(who: ActorRef[Nothing], id: Long)
 

--- a/src/test/scala/com/rolandkuhn/akka_typed_session/auditdemo/ProcessBased.scala
+++ b/src/test/scala/com/rolandkuhn/akka_typed_session/auditdemo/ProcessBased.scala
@@ -6,7 +6,7 @@ package auditdemo
 
 import ScalaDSL._
 import java.net.URI
-import akka.typed.ActorRef
+import akka.actor.typed.ActorRef
 import akka.Done
 import scala.util.Random
 import scala.concurrent.duration._
@@ -21,7 +21,7 @@ object ProcessBased {
     OpDSL[Nothing] { implicit opDSL =>
       for {
         self <- opActorSelf
-        audit <- opCall(getService(AuditService).named("getAudit"))
+        audit <- opCall(getService(AuditService.Key).named("getAudit"))
         _ <- opCall(doAudit(audit, self, "starting payment").named("preAudit"))
         _ <- opCall(doPayment(from, amount, payments).named("payment"))
         _ <- opCall(doAudit(audit, self, "payment finished").named("postAudit"))


### PR DESCRIPTION
Hi Roland, I wanted to have a play with this so thought I'd update to the latest akka typed (master, not a released version).

The tests currently do not pass due to missing functionality in the
BehaviorTestKit. Specifically:
- Getting the inbox of an anonymously spawned child/adapter
- Partial function matching against Effects now they contain
props/behaviors

As well as messageAdapter being hard to use in this case as it
requires a ClassTag. I think a power user spawnAdapter should be
re-introduced with a warning about resource leaks.

I'll try to get to the above issues and revisit this PR then.